### PR TITLE
NoMethodError (undefined method `issue_statuses' for nil:NilClass):

### DIFF
--- a/app/controllers/taskboard_controller.rb
+++ b/app/controllers/taskboard_controller.rb
@@ -73,7 +73,7 @@ class TaskboardController < ApplicationController
       column_id = column_id.to_i
       unless column_id == 0
         @columnsn = TaskBoardColumn.find(column_id)
-        @column.issue_statuses << IssueStatus.find(status_id)
+        @columnsn.issue_statuses << IssueStatus.find(status_id)
       end
     end
     render 'settings/update'


### PR DESCRIPTION
...:Austin, thanks for this, hoping to contribute a bit back.  Sloncho is on the old redmine path but this is a good pull request that fixes a bug that prevented the linking of categories to the taskboard column from being saved.  The variable was misnamed.

Please commit it, and feel free to reach out to collaborate on this.  @djdarkbeat on twitter.
