### PR TITLE
Task board column db agnostic

### DIFF
--- a/app/models/task_board_column.rb
+++ b/app/models/task_board_column.rb
@@ -26,7 +26,7 @@ class TaskBoardColumn < ActiveRecord::Base
       @column_statuses[status.id] = Array.new
       issues = Issue.select("issues.*, tbi.is_archived, tbi.#{order_column} as weight, tbi.issue_id") \
         .joins('LEFT OUTER JOIN task_board_issues AS tbi ON tbi.issue_id = issues.id') \
-        .where("project_id IN (?) AND status_id = ? AND (is_archived IS NULL OR is_archived = FALSE)", subproject_ids, status.id) \
+        .where("project_id" => subproject_ids, "status_id" => status.id, "tbi.is_archived" => [nil, false]) \
         .order("weight ASC, created_on ASC")
       issues.each do |issue|
         # Create a TaskBoardIssue (i.e. a Card) if one doesn't exist already.


### PR DESCRIPTION
Fixes SQLite3::SQLException when accessing the taskboard with SQLite. It shouldn't (untested) break on other DB as we're using the abstraction layer.
This is the error I got before fixing:

```
Started GET "/projects/project1/taskboard" for 10.0.2.2 at 2015-07-12 10:39:23 +0000
Processing by TaskboardController#index as HTML
  Parameters: {"project_id"=>"project1"}
...
...
...
SQLite3::SQLException: no such column: FALSE: SELECT issues.*, tbi.is_archived, tbi.project_weight as weight, tbi.issue_id FROM "issues" LEFT OUTER JOIN task_board_issues AS tbi ON tbi.issue_id = issues.id WHERE (project_id IN (1) AND status_id = 1 AND (is_ar[260/1004]
NULL OR is_archived = FALSE)) ORDER BY weight ASC, created_on ASC
  Rendered plugins/redmine_task_board/app/views/taskboard/index.html.erb within layouts/base (901.8ms)
Completed 500 Internal Server Error in 2019.2ms

ActionView::Template::Error (SQLite3::SQLException: no such column: FALSE: SELECT issues.*, tbi.is_archived, tbi.project_weight as weight, tbi.issue_id FROM "issues" LEFT OUTER JOIN task_board_issues AS tbi ON tbi.issue_id = issues.id WHERE (project_id IN (1) AND statu
s_id = 1 AND (is_archived IS NULL OR is_archived = FALSE)) ORDER BY weight ASC, created_on ASC):
    20:   <% @columns.each do|column| %>
    21:     <div class="taskboard-pane">
    22:       <h2><%= column.title %></h2>
    23:       <% column.issues.each do |status_id, issues| %>
    24:         <% unless column.issues.size == 1 %>
    25:           <h3 class="status"><%= @status_names[status_id] %></h3>
    26:         <% end %>
  sqlite3 (1.3.10) lib/sqlite3/database.rb:91:in `initialize'
  sqlite3 (1.3.10) lib/sqlite3/database.rb:91:in `new'
  sqlite3 (1.3.10) lib/sqlite3/database.rb:91:in `prepare'
  activerecord (3.2.21) lib/active_record/connection_adapters/sqlite_adapter.rb:246:in `block in exec_query'
  activerecord (3.2.21) lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
  activesupport (3.2.21) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activerecord (3.2.21) lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
  activerecord (3.2.21) lib/active_record/connection_adapters/sqlite_adapter.rb:242:in `exec_query'
  activerecord (3.2.21) lib/active_record/connection_adapters/sqlite_adapter.rb:467:in `select'
  activerecord (3.2.21) lib/active_record/connection_adapters/abstract/database_statements.rb:18:in `select_all'
  activerecord (3.2.21) lib/active_record/connection_adapters/abstract/query_cache.rb:61:in `block in select_all'
  activerecord (3.2.21) lib/active_record/connection_adapters/abstract/query_cache.rb:75:in `cache_sql'
  activerecord (3.2.21) lib/active_record/connection_adapters/abstract/query_cache.rb:61:in `select_all'
  activerecord (3.2.21) lib/active_record/querying.rb:38:in `block in find_by_sql'
  activerecord (3.2.21) lib/active_record/explain.rb:41:in `logging_query_plan'
  activerecord (3.2.21) lib/active_record/querying.rb:37:in `find_by_sql'
  activerecord (3.2.21) lib/active_record/relation.rb:174:in `block in exec_queries'
  activerecord (3.2.21) lib/active_record/identity_map.rb:72:in `without'
  activerecord (3.2.21) lib/active_record/relation.rb:173:in `exec_queries'
  activerecord (3.2.21) lib/active_record/relation.rb:160:in `block in to_a'
  activerecord (3.2.21) lib/active_record/explain.rb:41:in `logging_query_plan'                                                                                                                                                                                    [226/1004]
  activerecord (3.2.21) lib/active_record/relation.rb:159:in `to_a'
  activerecord (3.2.21) lib/active_record/relation/delegation.rb:6:in `each'
  plugins/redmine_task_board/app/models/task_board_column.rb:31:in `block in issues'
  activerecord (3.2.21) lib/active_record/relation/delegation.rb:6:in `each'
  activerecord (3.2.21) lib/active_record/relation/delegation.rb:6:in `each'
  plugins/redmine_task_board/app/models/task_board_column.rb:25:in `issues'
  plugins/redmine_task_board/app/views/taskboard/index.html.erb:23:in `block in _plugins_redmine_task_board_app_views_taskboard_index_html_erb___1159350409674044433_27471600'
  plugins/redmine_task_board/app/views/taskboard/index.html.erb:20:in `each'
  plugins/redmine_task_board/app/views/taskboard/index.html.erb:20:in `_plugins_redmine_task_board_app_views_taskboard_index_html_erb___1159350409674044433_27471600'
  actionpack (3.2.21) lib/action_view/template.rb:145:in `block in render'
  activesupport (3.2.21) lib/active_support/notifications.rb:125:in `instrument'
  actionpack (3.2.21) lib/action_view/template.rb:143:in `render'
  actionpack (3.2.21) lib/action_view/renderer/template_renderer.rb:47:in `block (2 levels) in render_template'
  actionpack (3.2.21) lib/action_view/renderer/abstract_renderer.rb:38:in `block in instrument'
  activesupport (3.2.21) lib/active_support/notifications.rb:123:in `block in instrument'
  activesupport (3.2.21) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (3.2.21) lib/active_support/notifications.rb:123:in `instrument'
  actionpack (3.2.21) lib/action_view/renderer/abstract_renderer.rb:38:in `instrument'
  actionpack (3.2.21) lib/action_view/renderer/template_renderer.rb:46:in `block in render_template'
  actionpack (3.2.21) lib/action_view/renderer/template_renderer.rb:54:in `render_with_layout'
  actionpack (3.2.21) lib/action_view/renderer/template_renderer.rb:45:in `render_template'
  actionpack (3.2.21) lib/action_view/renderer/template_renderer.rb:18:in `render'
  actionpack (3.2.21) lib/action_view/renderer/renderer.rb:36:in `render_template'
  actionpack (3.2.21) lib/action_view/renderer/renderer.rb:17:in `render'
  actionpack (3.2.21) lib/abstract_controller/rendering.rb:110:in `_render_template'
  actionpack (3.2.21) lib/action_controller/metal/streaming.rb:225:in `_render_template'
  actionpack (3.2.21) lib/abstract_controller/rendering.rb:103:in `render_to_body'
  actionpack (3.2.21) lib/action_controller/metal/renderers.rb:28:in `render_to_body'
  actionpack (3.2.21) lib/action_controller/metal/compatibility.rb:50:in `render_to_body'
  actionpack (3.2.21) lib/abstract_controller/rendering.rb:88:in `render'
  actionpack (3.2.21) lib/action_controller/metal/rendering.rb:16:in `render'
  actionpack (3.2.21) lib/action_controller/metal/instrumentation.rb:40:in `block (2 levels) in render'
  activesupport (3.2.21) lib/active_support/core_ext/benchmark.rb:5:in `block in ms'
  /usr/lib/ruby/1.9.1/benchmark.rb:295:in `realtime'                                                                                                                                                                                                               [192/1004]
  activesupport (3.2.21) lib/active_support/core_ext/benchmark.rb:5:in `ms'
  actionpack (3.2.21) lib/action_controller/metal/instrumentation.rb:40:in `block in render'
  actionpack (3.2.21) lib/action_controller/metal/instrumentation.rb:83:in `cleanup_view_runtime'
  activerecord (3.2.21) lib/active_record/railties/controller_runtime.rb:24:in `cleanup_view_runtime'
  actionpack (3.2.21) lib/action_controller/metal/instrumentation.rb:39:in `render'
  actionpack (3.2.21) lib/action_controller/metal/implicit_render.rb:10:in `default_render'
  actionpack (3.2.21) lib/action_controller/metal/implicit_render.rb:5:in `send_action'
  actionpack (3.2.21) lib/abstract_controller/base.rb:167:in `process_action'
  actionpack (3.2.21) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (3.2.21) lib/abstract_controller/callbacks.rb:18:in `block in process_action'
  activesupport (3.2.21) lib/active_support/callbacks.rb:502:in `_run__2519480712681433457__process_action__2160616033504560337__callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.21) lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.21) lib/abstract_controller/callbacks.rb:17:in `process_action'
  actionpack (3.2.21) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (3.2.21) lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
  activesupport (3.2.21) lib/active_support/notifications.rb:123:in `block in instrument'
  activesupport (3.2.21) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (3.2.21) lib/active_support/notifications.rb:123:in `instrument'
  actionpack (3.2.21) lib/action_controller/metal/instrumentation.rb:29:in `process_action'
  actionpack (3.2.21) lib/action_controller/metal/params_wrapper.rb:207:in `process_action'
  activerecord (3.2.21) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (3.2.21) lib/abstract_controller/base.rb:121:in `process'
  actionpack (3.2.21) lib/abstract_controller/rendering.rb:45:in `process'
  actionpack (3.2.21) lib/action_controller/metal.rb:203:in `dispatch'
  actionpack (3.2.21) lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
  actionpack (3.2.21) lib/action_controller/metal.rb:246:in `block in action'
  actionpack (3.2.21) lib/action_dispatch/routing/route_set.rb:73:in `call'
  actionpack (3.2.21) lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
  actionpack (3.2.21) lib/action_dispatch/routing/route_set.rb:36:in `call'
  journey (1.0.4) lib/journey/router.rb:68:in `block in call'
  journey (1.0.4) lib/journey/router.rb:56:in `each'
  journey (1.0.4) lib/journey/router.rb:56:in `call'
  actionpack (3.2.21) lib/action_dispatch/routing/route_set.rb:608:in `call'
  rack-openid (1.4.2) lib/rack/openid.rb:98:in `call'
  request_store (1.0.5) lib/request_store/middleware.rb:9:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
  rack (1.4.7) lib/rack/etag.rb:23:in `call'
  rack (1.4.7) lib/rack/conditionalget.rb:25:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/head.rb:14:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/flash.rb:242:in `call'
  rack (1.4.7) lib/rack/session/abstract/id.rb:210:in `context'
  rack (1.4.7) lib/rack/session/abstract/id.rb:205:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/cookies.rb:341:in `call'
  activerecord (3.2.21) lib/active_record/query_cache.rb:64:in `call'
  activerecord (3.2.21) lib/active_record/connection_adapters/abstract/connection_pool.rb:479:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `_run__2433581030295988600__call__4467339316122754073__callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.21) lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.21) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/reloader.rb:65:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
  railties (3.2.21) lib/rails/rack/logger.rb:32:in `call_app'
  railties (3.2.21) lib/rails/rack/logger.rb:16:in `block in call'
  activesupport (3.2.21) lib/active_support/tagged_logging.rb:22:in `tagged'
  railties (3.2.21) lib/rails/rack/logger.rb:16:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/request_id.rb:22:in `call'
  rack (1.4.7) lib/rack/methodoverride.rb:21:in `call'
  rack (1.4.7) lib/rack/runtime.rb:17:in `call'
  activesupport (3.2.21) lib/active_support/cache/strategy/local_cache.rb:72:in `call'
  rack (1.4.7) lib/rack/lock.rb:15:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/static.rb:83:in `call'
  railties (3.2.21) lib/rails/engine.rb:484:in `call'
  railties (3.2.21) lib/rails/application.rb:231:in `call'
  rack (1.4.7) lib/rack/content_length.rb:14:in `call'
  railties (3.2.21) lib/rails/rack/log_tailer.rb:17:in `call'
  rack (1.4.7) lib/rack/handler/webrick.rb:59:in `service'
  /usr/lib/ruby/1.9.1/webrick/httpserver.rb:138:in `service'
  /usr/lib/ruby/1.9.1/webrick/httpserver.rb:94:in `run'
  /usr/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'
```