### PR TITLE
My task board controller db agnostic

### DIFF
--- a/app/controllers/my_taskboard_controller.rb
+++ b/app/controllers/my_taskboard_controller.rb
@@ -27,7 +27,7 @@ class MyTaskboardController < ApplicationController
         .joins('INNER JOIN trackers ON trackers.id = issues.tracker_id') \
         .joins('INNER JOIN projects ON projects.id = issues.project_id') \
         .joins('INNER JOIN enumerations issue_priority ON issues.priority_id = issue_priority.id') \
-        .where("assigned_to_id = ? AND issue_statuses.is_closed = 0 AND projects.status = 1", @user.id) \
+        .where("assigned_to_id" => @user.id, "issue_statuses.is_closed" => false, "projects.status" => 1) \
         .order("weight ASC, issue_priority.position DESC")
     @not_prioritized = Array.new
     @prioritized = Array.new


### PR DESCRIPTION
Fixes ActiveRecord::StatementInvalid when accessing the taskboard with PostgreSQL by using the abstraction layer.
This is the error I got before fixing:
```
Started GET "/my/taskboard" for 82.240.132.124 at 2015-07-12 14:18:37 +0000
  Current user: admin (id=1)

ActiveRecord::StatementInvalid (PG::UndefinedFunction: ERROR:  operator does not exist: boolean = integer
LINE 11: ... (assigned_to_id = 1 AND issue_statuses.is_closed = 0 AND pr...
                                                              ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: SELECT issues.id,
          issues.subject,
          issues.status_id,
          projects.name as project_name,
          trackers.name as tracker_name,
          issue_priority.name as priority_name,
          issue_priority.id as priority_id,
          projects.id as project_id,
          tba.weight,
          issue_statuses.name as status_name,
          tba.issue_id FROM "issues" LEFT OUTER JOIN task_board_assignees AS tba ON tba.issue_id = issues.id AND tba.assignee_id = issues.assigned_to_id INNER JOIN issue_statuses ON issues.status_id = issue_statuses.id INNER
r_id INNER JOIN projects ON projects.id = issues.project_id INNER JOIN enumerations issue_priority ON issues.priority_id = issue_priority.id WHERE (assigned_to_id = 1 AND issue_statuses.is_closed = 0 AND projects.status = 1)
 DESC):
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/postgresql_adapter.rb:1163:in `async_exec'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/postgresql_adapter.rb:1163:in `exec_no_cache'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/postgresql_adapter.rb:660:in `block in exec_query'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/postgresql_adapter.rb:659:in `exec_query'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/postgresql_adapter.rb:1262:in `select'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:18:in `select_all'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/query_cache.rb:61:in `block in select_all'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/query_cache.rb:75:in `cache_sql'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/query_cache.rb:61:in `select_all'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/querying.rb:38:in `block in find_by_sql'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/explain.rb:41:in `logging_query_plan'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/querying.rb:37:in `find_by_sql'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/relation.rb:174:in `block in exec_queries'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/identity_map.rb:72:in `without'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/relation.rb:173:in `exec_queries'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/relation.rb:160:in `block in to_a'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/explain.rb:41:in `logging_query_plan'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/relation.rb:159:in `to_a'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/relation/delegation.rb:6:in `each'
  plugins/redmine_task_board/app/controllers/my_taskboard_controller.rb:35:in `index'
  plugins/redmine_task_board/app/controllers/my_taskboard_controller.rb:7:in `my_index'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/abstract_controller/base.rb:167:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal/rendering.rb:10:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/abstract_controller/callbacks.rb:18:in `block in process_action'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:491:in `_run__3404452875432709422__process_action__834601124390536483__callbacks'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:405:in `__run_callback'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:81:in `run_callbacks'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/abstract_controller/callbacks.rb:17:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal/rescue.rb:29:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/notifications.rb:123:in `block in instrument'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/notifications.rb:123:in `instrument'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal/instrumentation.rb:29:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal/params_wrapper.rb:207:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/abstract_controller/base.rb:121:in `process'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/abstract_controller/rendering.rb:45:in `process'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal.rb:203:in `dispatch'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_controller/metal.rb:246:in `block in action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/routing/route_set.rb:73:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/routing/route_set.rb:36:in `call'
  vendor/bundle/ruby/2.0.0/gems/journey-1.0.4/lib/journey/router.rb:68:in `block in call'
  vendor/bundle/ruby/2.0.0/gems/journey-1.0.4/lib/journey/router.rb:56:in `each'
  vendor/bundle/ruby/2.0.0/gems/journey-1.0.4/lib/journey/router.rb:56:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/routing/route_set.rb:608:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-openid-1.4.2/lib/rack/openid.rb:98:in `call'
  vendor/bundle/ruby/2.0.0/gems/request_store-1.0.5/lib/request_store/middleware.rb:9:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/etag.rb:23:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/conditionalget.rb:25:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/head.rb:14:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/params_parser.rb:21:in `call'
Processing by MyTaskboardController#my_index as HTML
Completed 500 Internal Server Error in 10.5ms
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/flash.rb:242:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/session/abstract/id.rb:210:in `context'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/session/abstract/id.rb:205:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/cookies.rb:341:in `call'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/query_cache.rb:64:in `call'
  vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/connection_pool.rb:479:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:405:in `_run__2765468623595060914__call__1820860619230650084__callbacks'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:405:in `__run_callback'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/callbacks.rb:81:in `run_callbacks'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
  vendor/bundle/ruby/2.0.0/gems/railties-3.2.21/lib/rails/rack/logger.rb:32:in `call_app'
  vendor/bundle/ruby/2.0.0/gems/railties-3.2.21/lib/rails/rack/logger.rb:16:in `block in call'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/tagged_logging.rb:22:in `tagged'
  vendor/bundle/ruby/2.0.0/gems/railties-3.2.21/lib/rails/rack/logger.rb:16:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/request_id.rb:22:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/methodoverride.rb:21:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/runtime.rb:17:in `call'
  vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.21/lib/active_support/cache/strategy/local_cache.rb:72:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/lock.rb:15:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/static.rb:83:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-cache-1.2/lib/rack/cache/context.rb:136:in `forward'
  vendor/bundle/ruby/2.0.0/gems/rack-cache-1.2/lib/rack/cache/context.rb:245:in `fetch'
  vendor/bundle/ruby/2.0.0/gems/rack-cache-1.2/lib/rack/cache/context.rb:185:in `lookup'
  vendor/bundle/ruby/2.0.0/gems/rack-cache-1.2/lib/rack/cache/context.rb:66:in `call!'
  vendor/bundle/ruby/2.0.0/gems/rack-cache-1.2/lib/rack/cache/context.rb:51:in `call'
  vendor/bundle/ruby/2.0.0/gems/railties-3.2.21/lib/rails/engine.rb:484:in `call'
  vendor/bundle/ruby/2.0.0/gems/railties-3.2.21/lib/rails/application.rb:231:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/content_length.rb:14:in `call'
  vendor/bundle/ruby/2.0.0/gems/railties-3.2.21/lib/rails/rack/log_tailer.rb:17:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/handler/webrick.rb:59:in `service'
  vendor/ruby-2.0.0/lib/ruby/2.0.0/webrick/httpserver.rb:138:in `service'
  vendor/ruby-2.0.0/lib/ruby/2.0.0/webrick/httpserver.rb:94:in `run'
  vendor/ruby-2.0.0/lib/ruby/2.0.0/webrick/server.rb:295:in `block in start_thread'
```